### PR TITLE
Added naive server stats module

### DIFF
--- a/modules/server_stats.js
+++ b/modules/server_stats.js
@@ -1,0 +1,62 @@
+const Discord = require('discord.js')
+
+let buildEmbed = async (data) => {
+  let embed = new Discord.RichEmbed()
+  let embedField, embedValue
+  embed.setTitle(`Server stats for ${data.name}`)
+  data.fields.map(field => {
+    embedField = Object.entries(field)
+    embedValue = embedField[0][1].map(val => Object.values(val))
+                                 .map(x => `${x[1]} (${x[0]})`)
+    embed.addField(embedField[0][0], embedValue)
+  })
+  embed.setFooter(`Server created at ${data.creationDate}`)
+  return embed
+}
+
+let refreshCache = async (client) => {
+  for (let guild of client.guilds) {
+    let clientGuild = guild[1]
+    let guildData = {
+      name: clientGuild.name,
+      creationDate : clientGuild.createdAt,
+      fields: [{
+        roles: clientGuild.roles.map(x => [x.id, x.name]),
+      },
+      {
+        channels: clientGuild.channels.map(x => [x.id, x.name]),
+      }]
+    }
+    await client.guildData.set(`${clientGuild.id}.stats`, guildData)
+    client.log.info('Update server stats', client)
+  }
+}
+
+let stats = async (message, _) => {
+  let embedMessage = await buildEmbed(message.client.guildData.get(`${message.guild.id}.stats`))
+  return message.channel.send(embedMessage)
+}
+
+module.exports = {
+  name: 'server stats',
+  commands: [
+    {
+      name: 'stats',
+      description: 'Displays server statistics',
+      examples: ['stats'],
+      secret: false,
+      permissionLevel: 0,
+      minArgs: 0,
+      maxArgs: 0,
+      aliases: [],
+      run: stats
+    }
+  ],
+  jobs: [
+    {
+      period: 3600,
+      job: refreshCache,
+      runInstantly: true
+    }
+  ]
+}

--- a/modules/server_stats.js
+++ b/modules/server_stats.js
@@ -16,8 +16,8 @@ let buildEmbed = async (data) => {
 
 let refreshCache = async (client) => {
   for (let guild of client.guilds) {
-    let clientGuild = guild[1]
-    let guildData = {
+    const clientGuild = guild[1]
+    const guildData = {
       name: clientGuild.name,
       creationDate : clientGuild.createdAt,
       fields: [{
@@ -28,12 +28,11 @@ let refreshCache = async (client) => {
       }]
     }
     await client.guildData.set(`${clientGuild.id}.stats`, guildData)
-    client.log.info('Update server stats', client)
   }
 }
 
 let stats = async (message, _) => {
-  let embedMessage = await buildEmbed(message.client.guildData.get(`${message.guild.id}.stats`))
+  const embedMessage = await buildEmbed(message.client.guildData.get(`${message.guild.id}.stats`))
   return message.channel.send(embedMessage)
 }
 
@@ -44,11 +43,8 @@ module.exports = {
       name: 'stats',
       description: 'Displays server statistics',
       examples: ['stats'],
-      secret: false,
-      permissionLevel: 0,
       minArgs: 0,
       maxArgs: 0,
-      aliases: [],
       run: stats
     }
   ],

--- a/scepter.js
+++ b/scepter.js
@@ -104,7 +104,9 @@ client.on('message', async message => {
     Object.keys(client.loadedModules).forEach(async moduleIndex => {
       client.loadedModules[moduleIndex].commands.forEach(async command => {
         const commandName = message.content.split(prefix)[1].split(' ')[0]
-        const possibleNames = command.aliases.concat([command.name])
+        const possibleNames = command.aliases
+          ? command.aliases.concat([command.name])
+          : [command.name]
         if (possibleNames.includes(commandName)) {
           const messageContentWithoutPrefixOrCommandName = message.content.substr(prefix.length + 1 + commandName.length)
           runCommand(message, command, parseArgs(messageContentWithoutPrefixOrCommandName))

--- a/scepter.js
+++ b/scepter.js
@@ -38,7 +38,12 @@ if (!process.env.DISCORD_TOKEN) {
 const loadModule = name => {
   const module = require(`./modules/${name}`)
   if (module.jobs) {
-    module.jobs.map(x => setInterval(() => x.job(client), x.period * 1000))
+    module.jobs.map(x => {
+      setInterval(() => x.job(client), x.period * 1000)
+      if (x.runInstantly) {
+        x.job(client)
+      }
+    })
   }
   client.loadedModules[name] = module
 }


### PR DESCRIPTION
Changes to the Scepter kernel:
=========================
* The `jobs` export for modules now accepts a `runInstantly` parameter, which makes the kernel
execute the task once on module load, right after setting up the execution interval

How the module works
---------------------------
Every hour, the list of channels with IDs, roles with IDs, and the creation date (shouldn't change actually)
are refreshed and saved into the guildData enmap, for persistence.

Said data can be requested with the `s.stats` command. The command builds an embed to nicely
print the server information

What's missing
--------------------
* Possible extra data to add to the stats
* Better formatting?
* Testing cases in which the embed text exceeds the max length, and how to handle it

Closes #5