### PR TITLE
Colour roles module

### DIFF
--- a/modules/colours.ts
+++ b/modules/colours.ts
@@ -1,0 +1,61 @@
+import { Message, Role, Client, Guild } from 'discord.js'
+
+const HEX_COLOUR_REGEX = new RegExp('^#?[0-9a-f]{6}$')
+
+const setColourRole = async (message: Message, args: string[]) => {
+  let hexColour: string = args[0]
+  if (!HEX_COLOUR_REGEX.test(hexColour)) {
+    return message.channel.send(`${hexColour} is not a valid colour for a role!`)
+  }
+  if (message.member.roles.map(x => x.name).includes(hexColour)) {
+    return message.channel.send('You already have that colour!')
+  }
+  if (hexColour.length > 6) {
+    hexColour = hexColour.slice(1, 7)  // remove the pound sign
+  }
+  message.member.roles.filter(x => HEX_COLOUR_REGEX.test(x.name))
+        .forEach(role => message.member.removeRole(role))
+  const currentRoles: Role[] = message.client['guildData'].get(`${message.guild.id}.roles`)
+  debugger
+  let colourRole = currentRoles.find(x => x.name === hexColour)
+  if (colourRole == null) {
+    colourRole = await message.guild.createRole({
+      name: hexColour,
+      color: `#${hexColour}`
+    })
+    message.client['guildData'].set(
+      `${message.guild.id}.roles`, currentRoles.concat(colourRole)
+    )
+  }
+  await message.member.addRole(colourRole)
+
+}
+
+const refreshRoleCache = async (client: Client) => {
+  let clientGuild: Guild
+  debugger
+  for (let guild of client.guilds) {
+    clientGuild = guild[1]
+    client['guildData'].set(`${clientGuild.id}.roles`, [...clientGuild.roles.values()])
+  }
+}
+
+export const name = 'colour roles'
+export const loadOnBoot = false
+export const commands = [
+  {
+    name: 'setcolour',
+    aliases: ['setcolor'],
+    description: 'Self-assign a colour role',
+    minArgs: 1,
+    maxArgs: 1,
+    run: setColourRole
+  }
+]
+export const jobs = [
+  {
+    period: 3600,
+    runInstantly: true,
+    job: refreshRoleCache
+  }
+]

--- a/modules/colours.ts
+++ b/modules/colours.ts
@@ -1,4 +1,4 @@
-import { Message, Role, Client, Guild } from 'discord.js'
+import { Message, Role, Client, Guild, GuildMember } from 'discord.js'
 
 const HEX_COLOUR_REGEX = new RegExp('^#?[0-9a-fA-F]{6}$')
 
@@ -42,6 +42,12 @@ const refreshRoleCache = async (client: Client) => {
   }
 }
 
+const assignRandomColour = async (member: GuildMember) => {
+  const currentRoles = member.client['guildData'].get(`${member.guild.id}.roles`)
+  const randomColour: Role = currentRoles[Math.floor(Math.random() * currentRoles.length)]
+  await member.addRole(randomColour)
+}
+
 export const name = 'colour roles'
 export const loadOnBoot = false
 export const commands = [
@@ -59,5 +65,11 @@ export const jobs = [
     period: 3600,
     runInstantly: true,
     job: refreshRoleCache
+  }
+]
+export const events = [
+  {
+    trigger: 'guildMemberAdd',
+    event: assignRandomColour
   }
 ]

--- a/modules/colours.ts
+++ b/modules/colours.ts
@@ -34,7 +34,10 @@ const refreshRoleCache = async (client: Client) => {
   let clientGuild: Guild
   for (let guild of client.guilds) {
     clientGuild = guild[1]
-    client['guildData'].set(`${clientGuild.id}.roles`, [...clientGuild.roles.values()])
+    client['guildData'].set(
+      `${clientGuild.id}.roles`,
+      [...clientGuild.roles.values()].filter(x => HEX_COLOUR_REGEX.test(x.name))
+    )
   }
 }
 

--- a/modules/colours.ts
+++ b/modules/colours.ts
@@ -1,6 +1,6 @@
 import { Message, Role, Client, Guild } from 'discord.js'
 
-const HEX_COLOUR_REGEX = new RegExp('^#?[0-9a-f]{6}$')
+const HEX_COLOUR_REGEX = new RegExp('^#?[0-9a-fA-F]{6}$')
 
 const setColourRole = async (message: Message, args: string[]) => {
   let hexColour: string = args[0]
@@ -13,6 +13,7 @@ const setColourRole = async (message: Message, args: string[]) => {
   if (hexColour.length > 6) {
     hexColour = hexColour.slice(1, 7)  // remove the pound sign
   }
+  hexColour = hexColour.toLowerCase()
   message.member.roles.filter(x => HEX_COLOUR_REGEX.test(x.name))
         .forEach(role => message.member.removeRole(role))
   const currentRoles: Role[] = message.client['guildData'].get(`${message.guild.id}.roles`)
@@ -27,7 +28,7 @@ const setColourRole = async (message: Message, args: string[]) => {
     )
   }
   await message.member.addRole(colourRole)
-
+  await message.channel.send(`Successfully applied colour #${hexColour.toUpperCase()}`)
 }
 
 const refreshRoleCache = async (client: Client) => {

--- a/modules/colours.ts
+++ b/modules/colours.ts
@@ -16,7 +16,6 @@ const setColourRole = async (message: Message, args: string[]) => {
   message.member.roles.filter(x => HEX_COLOUR_REGEX.test(x.name))
         .forEach(role => message.member.removeRole(role))
   const currentRoles: Role[] = message.client['guildData'].get(`${message.guild.id}.roles`)
-  debugger
   let colourRole = currentRoles.find(x => x.name === hexColour)
   if (colourRole == null) {
     colourRole = await message.guild.createRole({
@@ -33,7 +32,6 @@ const setColourRole = async (message: Message, args: string[]) => {
 
 const refreshRoleCache = async (client: Client) => {
   let clientGuild: Guild
-  debugger
   for (let guild of client.guilds) {
     clientGuild = guild[1]
     client['guildData'].set(`${clientGuild.id}.roles`, [...clientGuild.roles.values()])

--- a/tslint.json
+++ b/tslint.json
@@ -1,3 +1,6 @@
 {
-  "extends": "tslint-config-standard"
+  "extends": "tslint-config-standard",
+  "rules": {
+      "no-debugger": true
+  }
 }


### PR DESCRIPTION
# Current functionality:
 * Hourly caches the current server roles
 * On request, validates:
   * Whether the requested colour is a valid hex code
   * If the user doesn't already have that colour assigned
 * Removes all other assigned colours
 * Tries to find that colour in the stored cache.
   * If HIT: assigns that role to the user
   * If MISS: creates the role, adds it to the cache, and assigns it to the user

# Pending:

- [x] Right now the guildMemberUpdate event this triggers interferes with the mutes module, making it throw unhandledrejection errors

- [x] Could maybe thin down the cache to only store roles that match the colour regex

- [x] Code Review and possible refactors

- [x] Add a confirmation message when the role is assigned

- [x] Mixing uppercase and lowercase letters causes role duplication

- [x] Implement random colour assignment on member join