### PR TITLE
revamped permissions + coin flip module

### DIFF
--- a/modules/coin_flip.ts
+++ b/modules/coin_flip.ts
@@ -1,0 +1,30 @@
+import { Message } from 'discord.js'
+
+export const name = 'coin flip'
+export const commands = [
+  {
+    name: 'flip',
+    secret: false,
+    description: 'Flips a coin',
+    examples: ['!flip => Tails'],
+    minArgs: 0,
+    run: async (message: Message) => {
+      let flip: string = flipC() + '!'
+      try {
+        return await message.reply(flip)
+      } catch (e) {
+        throw e
+      }
+    }
+  }
+]
+
+// returns a random "Heads" or "Tails"
+function flipC(): string {
+  let random: number = Math.round(Math.random())
+  if (random === 1) {
+    return 'Heads'
+  } else {
+    return 'Tails'
+  }
+}

--- a/modules/echo.ts
+++ b/modules/echo.ts
@@ -7,7 +7,6 @@ export const commands = [
     secret: false, // optional, default false unless permissionLevel is 3, then it's true
     description: 'Takes your input and spits it right back at you.', // required if not secret
     examples: ['yes'], // required if not secret
-    permissionLevel: 0, // optional, default 0 | 0: anyone, 1: server mods, 2: server admins, 3: bot admins
     aliases: [], // optional
     cooldown: 0, // optional, default 0
     minArgs: 1, // required

--- a/modules/echo.ts
+++ b/modules/echo.ts
@@ -7,10 +7,12 @@ export const commands = [
     secret: false, // optional, default false unless permissionLevel is 3, then it's true
     description: 'Takes your input and spits it right back at you.', // required if not secret
     examples: ['yes'], // required if not secret
+    permissions: ["SEND_MESSAGES"], // more at https://discord.js.org/#/docs/main/stable/class/Permissions?scrollTo=s-FLAGS
     aliases: [], // optional
     cooldown: 0, // optional, default 0
     minArgs: 1, // required
     maxArgs: Infinity, // required
+    
     run: async (message: Message, args: string[]) => {
       let out = args.join(' ')
       try {


### PR DESCRIPTION
**Re-forked and re-made pull request to be fully consistent with the branches, sorry for any trouble this might cause...**

Permission Revamp
---
Implemented a permission system that allows you to specify which [permissions](https://discord.js.org/#/docs/main/stable/class/Permissions?scrollTo=s-FLAGS) your command requires of the user, in-order to execute.

**Old** "Command" structure:
```
type Command = {
  name: string,
  description: string,
  ...
  permissionLevel?: number,
  ...
}
```

**New** structure:
```
type Command = {
  name: string,
  description: string,
  ...
  permissions?: PermissionResolvable[],
  ...
}
```

**Usage example:**
`permissions: ['MANAGE_NICKNAMES', 'MANAGE_ROLES' ... ]`

Coin Flip Module
---
Added coin flip module.

**Usage:**
`
s.flip
`

**Output example:**
`
@User#0000, Tails!
`